### PR TITLE
Add workflow for auto-creating i18n pull requests

### DIFF
--- a/.github/workflows/auto-pr-i18n.yml
+++ b/.github/workflows/auto-pr-i18n.yml
@@ -1,0 +1,31 @@
+name: Auto Create i18n PR on New Commits
+
+on:
+    push:
+        branches:
+            - i18n
+
+jobs:
+    create_pull_request:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+
+        steps:
+        - name: Checkout Repository
+          uses: actions/checkout@v4
+          with:
+            fetch-depth: 0 # fetch all history to check diffs
+
+        - name: Check for new commits not in main and create PR
+          id: create-pr
+          uses: peter-evans/create-pull-request@v6
+          with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+            commit-message: Automatic pull request update
+            title: "i18n: Latest from Weblate"
+            body: |
+                The latest changes from weblate.
+            branch: ${{ github.ref }}
+            base: main


### PR DESCRIPTION
This workflow automatically creates a pull request for internationalization updates when new commits are pushed to the 'i18n' branch.