### PR TITLE
Fix/final v13 bugs

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -612,6 +612,7 @@
   "CALENDARIA.Editor.Error.MinOneWeekday": "Calendar must have at least one weekday.",
   "CALENDARIA.Editor.Error.NameRequired": "Calendar must have a name.",
   "CALENDARIA.Editor.ExportSuccess": "Exported \"{name}\" successfully.",
+  "CALENDARIA.Editor.Festival.PendingImport": "{count} imported festivals will be created when you save this calendar. Review the other tabs, then reopen the calendar to edit them.",
   "CALENDARIA.Editor.Festival.ResetConfirm": "Delete all festival notes for this calendar and re-create them from the bundled template?",
   "CALENDARIA.Editor.Festival.ResetDone": "Reset complete. Seeded {count} festival notes from the bundled template.",
   "CALENDARIA.Editor.Festival.ResetLabel": "Reset to Bundled",

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,16 +1,8 @@
-## New Features
-
-- Added a Sticky Tray option to the Time Keeper, via a Pin Controls toggle in the context menu and a matching checkbox on the Time Keeper settings tab, that keeps the hover-revealed controls tray open. The pinned state persists and survives increment changes and settings saves.
-- Added a Suppression Muffle slider on the Weather settings tab that keeps a fraction of weather sound volume inside Suppress Weather regions instead of fully silencing them, defaulting to 0 so existing regions stay silent.
-- Note Viewer search now matches note body text (HTML stripped) in addition to titles, grouping hits into Direct Matches for title matches and Mentioned for body-only matches.
-
 ## Bug Fixes
 
-- Clicking a cal.date enricher link now opens the calendar on the displayed year, fixing month notes not appearing on calendars with a non-zero yearZero (e.g. SWADE).
-- Duration-based seasons now cycle correctly across year boundaries, so seasons longer than a year or whose durations do not sum to the year length carry over instead of resetting each year.
-- Manual sunrise and sunset overrides in a climate zone now persist after saving and reopening, and the Shortest/Longest Day readout updates immediately.
-- Multiple moons in the HUD and sun dial now sort by name to match the calendar moon panel, so labels line up with their discs, and fully lit and fully dark rendering is reserved for true Full and New phases so gibbous and crescent moons keep a visible terminator.
-- Season conditions in the note condition builder now match correctly. A newly selected dropdown field defaults to its first option instead of silently filtering out every date, and Day in Season and Season Progress resolve against leap-aware season bounds for month-based and periodic calendars.
-- The Calendar Editor date-format preview now resolves [namedWeek] and [namedWeekAbbr] tokens from raw calendar data instead of leaving an empty gap.
-- The cinematic overlay date label now shows the full calendar display year instead of the internal year, fixing a mismatch in the keyframe date comparison.
-- The settings panel footer now uses the correct light-theme background and border, matching the calendar editor footer instead of showing dark-theme styling.
+- Fantasy-Calendar imports place festivals on the correct days, keep multi-day festival durations, and import whole-month festivals. The Festivals tab shows a notice that imported festivals are created when you save the calendar.
+- Fixed a delay before the clock widgets updated on time changes in worlds with many darkness-synced scenes.
+- Note content saves automatically when you switch tabs, return to view mode, or close the note editor. The redundant save button on the content editor has been removed.
+- Players taking a short or long rest with Advance Time on Rest enabled no longer receive a permission error. The GM drives rest time advancement.
+- The HUD and sun dial moon waxes and wanes smoothly across the cycle and stays visible near the new moon, instead of freezing for several days and vanishing.
+- The time increment dropdown in the HUD, mini calendar, and time keeper keeps your chosen step size instead of reverting to minutes.

--- a/scripts/applications/calendar/calendar-editor.mjs
+++ b/scripts/applications/calendar/calendar-editor.mjs
@@ -377,6 +377,9 @@ export class CalendarEditor extends HandlebarsApplicationMixin(ApplicationV2) {
       typeOptions: monthTypeOptions.map((opt) => ({ ...opt, selected: (opt.value || null) === (month.type || null) }))
     }));
     const festivalStubs = this.#calendarId ? FestivalManager.getFestivalNotes(this.#calendarId) : [];
+    const festivalDefs = this.#calendarData.festivals;
+    const festivalDefCount = Array.isArray(festivalDefs) ? festivalDefs.length : Object.keys(festivalDefs ?? {}).length;
+    context.festivalPendingImport = !this.#calendarId && festivalDefCount > 0 ? festivalDefCount : 0;
     context.festivalsCanEditNotes = !!(this.#isEditing && this.#calendarId);
     context.festivalsIsBundled = !!(this.#calendarId && isBundledCalendar(this.#calendarId));
     context.festivalsWithNav = festivalStubs.map((stub) => {

--- a/scripts/applications/dialogs/importer-app.mjs
+++ b/scripts/applications/dialogs/importer-app.mjs
@@ -400,7 +400,8 @@ export class ImporterApp extends HandlebarsApplicationMixin(ApplicationV2) {
           }
           return;
         }
-        if (noteType === 'festival') newFestivals.push({ name: note.name, month: note.startDate?.month ?? 0, dayOfMonth: note.startDate?.dayOfMonth ?? 0, countsForWeekday: false });
+        if (noteType === 'festival')
+          newFestivals.push({ name: note.name, month: note.startDate?.month ?? 0, dayOfMonth: note.startDate?.dayOfMonth ?? 0, duration: note.duration ?? 1, countsForWeekday: true });
       });
       if (newFestivals.length > 0) {
         if (!this.#transformedData.festivals) this.#transformedData.festivals = [];

--- a/scripts/applications/hud/hud-scene-renderer.mjs
+++ b/scripts/applications/hud/hud-scene-renderer.mjs
@@ -1130,7 +1130,7 @@ export class HudSceneRenderer {
     const hoursPerPixel = nightHours / arcPixels;
     const trailHours = trailSpacing * hoursPerPixel;
     for (let i = 0; i < count; i++) {
-      const { phase: moonPhase, color, isFull, isNew } = moons[i];
+      const { phase: moonPhase, color } = moons[i];
       const { glow, sprite, shadow } = this.#moonPool[i];
       glow.alpha = moonAlpha;
       sprite.alpha = moonAlpha;
@@ -1167,9 +1167,7 @@ export class HudSceneRenderer {
       sprite.scale.set(moonSize / 24);
       sprite.tint = 0xffffff;
       const rad = moonSize / 2;
-      let illumination = 1 - Math.abs(moonPhase * 2 - 1);
-      if (!isFull) illumination = Math.min(illumination, 0.7);
-      if (!isNew) illumination = Math.max(illumination, 0.3);
+      const lit = 0.08 + 0.84 * (1 - Math.abs(moonPhase * 2 - 1));
       const isWaxing = moonPhase < 0.5;
       glow.clear();
       if (color) {
@@ -1185,22 +1183,7 @@ export class HudSceneRenderer {
       glow.lineStyle(1, 0xffffff, 0.12);
       glow.drawCircle(moonX, moonY, rad + 1);
       shadow.clear();
-      if (illumination < 0.02) {
-        sprite.alpha = 0;
-        glow.alpha = 0;
-        shadow.alpha = 0;
-        continue;
-      }
-      if (illumination > 0.98) {
-        sprite.mask = null;
-        glow.mask = null;
-        if (shadow._prevMask && shadow._prevMask !== shadow) {
-          shadow._prevMask.destroy();
-          shadow._prevMask = null;
-        }
-        continue;
-      }
-      const terminatorRx = rad * Math.cos(illumination * Math.PI);
+      const terminatorRx = rad * (1 - 2 * lit);
       const k = 0.5522847498;
       shadow.beginFill(0xffffff);
       if (isWaxing) {

--- a/scripts/applications/sheets/calendar-note-sheet.mjs
+++ b/scripts/applications/sheets/calendar-note-sheet.mjs
@@ -114,8 +114,24 @@ export class CalendarNoteSheet extends HandlebarsApplicationMixin(foundry.applic
     super._configureRenderOptions(options);
   }
 
+  /**
+   * Flush the note content editor into the document before a re-render or close.
+   * The content prose-mirror only commits on its own save button, so leaving edit
+   * mode or closing would otherwise drop unsaved text.
+   * @returns {Promise<void>}
+   * @private
+   */
+  async #flushContent() {
+    if (!this.isEditMode || !this.document?.isOwner) return;
+    const editor = this.element?.querySelector('prose-mirror[name="text.content"]');
+    if (!editor) return;
+    const content = editor.value;
+    if (content != null && content !== (this.document.text?.content ?? '')) await this.document.update({ 'text.content': content }, { render: false });
+  }
+
   /** @override */
   async _onClose(options) {
+    await this.#flushContent();
     if (this._isNewNote && this.document) {
       const journal = this.document.parent;
       if (!journal || !game.journal.has(journal.id)) return super._onClose(options);
@@ -738,6 +754,8 @@ export class CalendarNoteSheet extends HandlebarsApplicationMixin(foundry.applic
     const newCategories = submitData.system?.categories || [];
     const oldCategories = this.document.system.categories || [];
     const addedPreset = newCategories.find((id) => !oldCategories.includes(id));
+    // Keep the active content editor (and its focus) alive across auto-submits; previews update in _onChangeForm.
+    if (!('render' in options)) options.render = false;
     NoteManager.enableSuppressOwnershipRebuild();
     try {
       await super._processSubmitData(event, form, submitData, options);
@@ -1054,6 +1072,7 @@ export class CalendarNoteSheet extends HandlebarsApplicationMixin(foundry.applic
    */
   static async _onToggleMode(_event, _target) {
     if (!this.document.isOwner) return;
+    await this.#flushContent();
     this._mode = this._mode === CalendarNoteSheet.MODES.VIEW ? CalendarNoteSheet.MODES.EDIT : CalendarNoteSheet.MODES.VIEW;
     const windowContent = this.element.querySelector('.window-content');
     if (windowContent) windowContent.innerHTML = '';

--- a/scripts/importers/fantasy-calendar-importer.mjs
+++ b/scripts/importers/fantasy-calendar-importer.mjs
@@ -434,6 +434,15 @@ export default class FantasyCalendarImporter extends BaseImporter {
     const isOneTimeEvent = Array.isArray(event.data?.date) && event.data.date.length >= 3;
     const isRandomEvent = eventType.repeat === 'random';
     const suggestedType = isOneTimeEvent || isRandomEvent ? 'note' : 'festival';
+    // A Month condition with no Day means the event spans that whole month in FC.
+    const conditionTypes = new Set(
+      this.#flattenConditions(conditions)
+        .map((c) => c[0])
+        .filter(Boolean)
+    );
+    const isWholeMonth = !hasDate && conditionTypes.has('Month') && !conditionTypes.has('Day') && !conditionTypes.has('Date');
+    const monthLength = data?.static_data?.year_data?.timespans?.[date.month]?.length;
+    const duration = isWholeMonth && monthLength ? monthLength : (event.data?.duration ?? 1);
     const noteData = {
       name: event.name,
       content: event.description || '',
@@ -443,7 +452,7 @@ export default class FantasyCalendarImporter extends BaseImporter {
       visibility: isHidden ? 'hidden' : 'visible',
       category: category?.name || 'default',
       color: FC_COLORS[event.settings?.color] || category?.color || '#2196f3',
-      duration: event.data?.duration || 1,
+      duration,
       originalId: event.id,
       suggestedType
     };

--- a/scripts/integrations/rest-time.mjs
+++ b/scripts/integrations/rest-time.mjs
@@ -40,6 +40,7 @@ export function onPreRest(_actor, config) {
  * @returns {void}
  */
 export function onLongRest(actor, config) {
+  if (!game.user.isGM) return;
   if (TimeClock.locked) return;
   const advanceTime = game.settings.get(MODULE.ID, SETTINGS.ADVANCE_TIME_ON_REST);
   if (!advanceTime) return;
@@ -95,6 +96,7 @@ export function onLongRest(actor, config) {
  * @returns {void}
  */
 export function onShortRest(actor, config) {
+  if (!game.user.isGM) return;
   if (TimeClock.locked) return;
   const advanceTime = game.settings.get(MODULE.ID, SETTINGS.ADVANCE_TIME_ON_REST);
   if (!advanceTime) return;
@@ -132,6 +134,7 @@ export function onShortRest(actor, config) {
  * @returns {void}
  */
 export function onPF2eRest() {
+  if (!game.user.isGM) return;
   if (pf2eRestTimer) return;
   pf2eRestTimer = setTimeout(() => {
     pf2eRestTimer = null;
@@ -181,6 +184,7 @@ export function onPF2eRest() {
  * @returns {void}
  */
 export function onPF1eRest(_actor, options = {}) {
+  if (!game.user.isGM) return;
   if (!options.hours) return;
   if (pf1eRestTimer) return;
   pf1eRestTimer = setTimeout(() => {

--- a/scripts/time/darkness.mjs
+++ b/scripts/time/darkness.mjs
@@ -318,12 +318,9 @@ export async function updateDarknessFromWorldTime(worldTime, dt) {
     const darkness = calculateAdjustedDarkness(baseDarkness, scene);
     const lighting = calculateEnvironmentLighting(scene);
     const envData = buildEnvironmentUpdateData(scene, lighting);
-    const updateData = { 'environment.darknessLevel': darkness, ...envData };
-    return scene.update(updateData, { animateDarkness }).catch((error) => {
-      log(1, `Darkness update failed for scene ${scene.name}:`, error);
-    });
+    return { _id: scene.id, 'environment.darknessLevel': darkness, ...envData };
   });
-  await Promise.all(updates);
+  if (updates.length) await Scene.updateDocuments(updates, { animateDarkness }).catch((error) => log(1, 'Darkness batch update failed:', error));
 }
 
 /**
@@ -390,12 +387,9 @@ export async function onWeatherChange() {
     const darkness = calculateAdjustedDarkness(baseDarkness, scene);
     const lighting = calculateEnvironmentLighting(scene);
     const envData = buildEnvironmentUpdateData(scene, lighting);
-    const updateData = { 'environment.darknessLevel': darkness, ...envData };
-    return scene.update(updateData).catch((error) => {
-      log(1, `Weather darkness update failed for scene ${scene.name}:`, error);
-    });
+    return { _id: scene.id, 'environment.darknessLevel': darkness, ...envData };
   });
-  await Promise.all(updates);
+  if (updates.length) await Scene.updateDocuments(updates).catch((error) => log(1, 'Weather darkness batch update failed:', error));
 }
 
 /**

--- a/scripts/time/time-clock.mjs
+++ b/scripts/time/time-clock.mjs
@@ -30,6 +30,18 @@ export function getTimeIncrements() {
 }
 
 /**
+ * Resolve an increment value to a valid string key, coercing a numeric index to its key.
+ * @param {Object<string, number>} increments - Increment map from getTimeIncrements()
+ * @param {string|number} key - Increment key or numeric index
+ * @returns {string|number} Resolved string key, or the original value if it cannot be resolved
+ */
+function resolveIncrementKey(increments, key) {
+  if (increments[key] != null) return key;
+  if (/^\d+$/.test(String(key))) return Object.keys(increments)[Number(key)] ?? key;
+  return key;
+}
+
+/**
  * Real-time clock controller for advancing game time automatically.
  */
 export default class TimeClock {
@@ -304,6 +316,7 @@ export default class TimeClock {
    */
   static setIncrement(key) {
     const increments = getTimeIncrements();
+    key = resolveIncrementKey(increments, key);
     if (!increments[key]) return;
     this.#incrementKey = key;
     this.#increment = increments[key];
@@ -327,6 +340,7 @@ export default class TimeClock {
    */
   static setAppIncrement(appId, key) {
     const increments = getTimeIncrements();
+    key = resolveIncrementKey(increments, key);
     if (!increments[key]) {
       log(2, `Invalid increment key: ${key}`);
       return;

--- a/scripts/time/time-clock.mjs
+++ b/scripts/time/time-clock.mjs
@@ -632,10 +632,10 @@ export default class TimeClock {
    * @param {number} dt - The delta time in seconds
    */
   static async onUpdateWorldTime(worldTime, dt) {
-    await updateDarknessFromWorldTime(worldTime, dt);
     ReminderScheduler.onUpdateWorldTime(worldTime, dt);
     TimeTracker.onUpdateWorldTime(worldTime, dt);
     Hooks.callAll(HOOKS.WORLD_TIME_UPDATED, worldTime, dt);
+    updateDarknessFromWorldTime(worldTime, dt);
     await EventScheduler.onUpdateWorldTime(worldTime, dt);
   }
 }

--- a/styles/note-sheet.css
+++ b/styles/note-sheet.css
@@ -613,6 +613,11 @@
           color: var(--calendaria-text);
           background: var(--calendaria-bg-lighter);
 
+          /* Content auto-saves on tab/mode change and close, so the editor's own save button is redundant. */
+          li:has(> button[data-action='save']) {
+            display: none;
+          }
+
           button {
             color: var(--calendaria-text-dim);
 

--- a/templates/chat/release-message.hbs
+++ b/templates/chat/release-message.hbs
@@ -10,24 +10,16 @@
             class="fa-brands fa-patreon"></i> Now on Patreon!</a></strong>
     </p>
 
-    <h4>New Features</h4>
-    <ul>
-      <li>Added a Sticky Tray option to the Time Keeper that keeps the controls tray pinned open instead of auto-hiding,
-        toggled from the context menu or its settings tab</li>
-      <li>Note search now looks inside note text as well as titles, grouping results into direct title matches and
-        mentions</li>
-      <li>Added a weather Suppression Muffle slider so weather sound can stay faintly audible inside suppression regions
-        instead of going fully silent</li>
-    </ul>
-
     <h4>Bug Fixes</h4>
     <ul>
-      <li>Multiple moons in the HUD and sun dial now line up with their calendar order, and gibbous and crescent moons
-        keep a visible terminator instead of rendering fully lit or dark</li>
-      <li>Seasons set by duration now carry across year boundaries instead of resetting each year</li>
-      <li>Season conditions in note recurrence now match correctly instead of filtering out every date</li>
-      <li>Clicking an in-text calendar date link now opens the calendar on the correct year</li>
-      <li>Manual sunrise and sunset overrides in a climate zone now stay saved after reopening the editor</li>
+      <li>Calendar notes now save on their own when you switch tabs or close the editor</li>
+      <li>Imported Fantasy-Calendar festivals now land on the right days and keep their multi-day and whole-month
+        spans</li>
+      <li>Players taking a rest no longer get an error when the calendar advances time on rest</li>
+      <li>The moon in the HUD and sun dial now changes shape smoothly through the month and stays visible at the new
+        moon</li>
+      <li>The time step dropdown on the clock widgets keeps your choice instead of snapping back to minutes</li>
+      <li>Time changes update the clock instantly again in worlds with many scenes</li>
     </ul>
 
   </div>

--- a/templates/editor/tab-festivals.hbs
+++ b/templates/editor/tab-festivals.hbs
@@ -17,6 +17,11 @@
         </button>
       {{/if}}
     </div>
+    {{#if festivalPendingImport}}
+      <div class="notification info">
+        {{localize "CALENDARIA.Editor.Festival.PendingImport" count=festivalPendingImport}}
+      </div>
+    {{/if}}
     {{#if festivalsWithNav.length}}
       <div class="items-list festivals-list">
         {{#each festivalsWithNav}}


### PR DESCRIPTION
- [#753] Note content saves automatically when you switch tabs, return to view mode, or close the note editor. The redundant save button on the content editor has been removed.
- [#754] The time increment dropdown in the HUD, mini calendar, and time keeper keeps your chosen step size instead of reverting to minutes.
- [#756] Players taking a short or long rest with Advance Time on Rest enabled no longer receive a permission error. The GM drives rest time advancement.
- [#758] Fixed a delay before the clock widgets updated on time changes in worlds with many darkness-synced scenes.
- [#759] The HUD and sun dial moon waxes and wanes smoothly across the cycle and stays visible near the new moon, instead of freezing for several days and vanishing.
- [#760] Fantasy-Calendar imports place festivals on the correct days, keep multi-day festival durations, and import whole-month festivals. The Festivals tab shows a notice that imported festivals are created when you save the calendar.