### PR TITLE
Patch/july 1

### DIFF
--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,7 +1,18 @@
 ## New Features
 
-- Added a View Note Viewer permission that hides the Note Viewer button from chosen roles.
+- The Chronicle scrolls to today's entry when first opened, unless it was opened with a locked date range.
+- The Note Viewer scrolls to the first note dated on or after today and places it at the top of the list when first opened.
 
 ## Bug Fixes
 
-- The Note Viewer note count no longer reveals the number of hidden notes to players.
+- Festivals with an image file icon such as an SVG now render that image on the calendar grid and in the festival editor list instead of nothing.
+- The chat card Release Notes link now points to the correct repository.
+- The Chronicle hover Add Note quick-add button now appears for any player with note-creation permission in both the scroll and timeline layouts, not only the GM.
+- The HUD dome sun, moon, and stars render sharper at high resolution and scale with the dial size.
+- The sun dial no longer jumps the time around on repeated drags or center-input edits.
+- You can now set Seconds Per Round to zero on the calendar Time tab, which stops world time from advancing when combat rounds change.
+
+## Changes
+
+- Darkness sync no longer rewrites scenes whose darkness and lighting already match the computed values, cutting redundant scene updates.
+- The Chronicle, Stop Watch, and Sun Dial settings tabs now show the open, reset position, and close controls to any non-GM user holding that app's view permission.

--- a/scripts/applications/calendar/big-cal.mjs
+++ b/scripts/applications/calendar/big-cal.mjs
@@ -430,6 +430,7 @@ export class BigCal extends HandlebarsApplicationMixin(ApplicationV2) {
           festivalName: !isFogged && fi?.showVisuals ? fi.name : '',
           festivalColor: !isFogged && fi?.showVisuals ? fi.color : '',
           festivalIcon: !isFogged && fi?.showVisuals ? fi.icon : '',
+          festivalIconIsImage: !isFogged && fi?.showVisuals ? fi.iconIsImage : false,
           festivalDescription: !isFogged ? fi?.description || '' : '',
           festivalNoteId: !isFogged ? fi?.note?.id || '' : '',
           dayTooltip: isFogged ? '' : generateDayTooltip(calendar, year, month, dayOfMonth, festivalInfo, wd, dayNotes),
@@ -454,6 +455,7 @@ export class BigCal extends HandlebarsApplicationMixin(ApplicationV2) {
           festivalName: !isFogged && fi?.showVisuals ? fi.name : '',
           festivalColor: !isFogged && fi?.showVisuals ? fi.color : '',
           festivalIcon: !isFogged && fi?.showVisuals ? fi.icon : '',
+          festivalIconIsImage: !isFogged && fi?.showVisuals ? fi.iconIsImage : false,
           festivalDescription: !isFogged ? fi?.description || '' : '',
           festivalNoteId: !isFogged ? fi?.note?.id || '' : '',
           dayTooltip: isFogged ? '' : generateDayTooltip(calendar, year, month, dayOfMonth, festivalInfo, wd, dayNotes),
@@ -606,6 +608,7 @@ export class BigCal extends HandlebarsApplicationMixin(ApplicationV2) {
         }
         const weekdayData = calendar.weekdaysArray[i % daysInWeek];
         const festivalNoteId = this._getFestivalNoteId(festivalDay);
+        const festivalIconIsImage = typeof festivalDay?.icon === 'string' && !festivalDay.icon.startsWith('fa') && (festivalDay.icon.includes('/') || festivalDay.icon.includes('.'));
         const dayData = {
           day: dayNum,
           dayOfMonth,
@@ -618,7 +621,8 @@ export class BigCal extends HandlebarsApplicationMixin(ApplicationV2) {
           isFestival: !dayIsFogged && !!festivalDay,
           festivalName: !dayIsFogged && festivalDay ? _loc(festivalDay.name) : null,
           festivalColor: !dayIsFogged ? festivalDay?.color || '' : '',
-          festivalIcon: !dayIsFogged && festivalDay?.icon ? `fas ${festivalDay.icon}` : '',
+          festivalIconIsImage: !dayIsFogged && festivalIconIsImage,
+          festivalIcon: !dayIsFogged && festivalDay?.icon ? (festivalIconIsImage ? festivalDay.icon : `fas ${festivalDay.icon}`) : '',
           festivalNoteId: dayIsFogged ? '' : festivalNoteId,
           moonPhases,
           isRestDay: weekdayData?.isRestDay || false,

--- a/scripts/applications/calendar/calendar-editor.mjs
+++ b/scripts/applications/calendar/calendar-editor.mjs
@@ -973,7 +973,8 @@ export class CalendarEditor extends HandlebarsApplicationMixin(ApplicationV2) {
     this.#calendarData.days.hoursPerDay = parseInt(data['days.hoursPerDay']) || 24;
     this.#calendarData.days.minutesPerHour = parseInt(data['days.minutesPerHour']) || 60;
     this.#calendarData.days.secondsPerMinute = parseInt(data['days.secondsPerMinute']) || 60;
-    this.#calendarData.secondsPerRound = parseInt(data.secondsPerRound) || 6;
+    const spr = parseInt(data.secondsPerRound);
+    this.#calendarData.secondsPerRound = Number.isFinite(spr) ? spr : 6;
     if (!this.#calendarData.daylight) this.#calendarData.daylight = {};
     this.#calendarData.daylight.enabled = data['daylight.enabled'] ?? false;
     const shortRaw = parseFloat(data['daylight.shortestDay']);

--- a/scripts/applications/calendar/calendar-editor.mjs
+++ b/scripts/applications/calendar/calendar-editor.mjs
@@ -388,11 +388,14 @@ export class CalendarEditor extends HandlebarsApplicationMixin(ApplicationV2) {
       let conditionSummary = tree ? summarizeConditionTree(tree, this.#calendarData) : '';
       const duration = fd.duration ?? 1;
       if (conditionSummary && duration > 1) conditionSummary += ` (${duration} ${_loc('CALENDARIA.Common.UnitDays')})`;
+      const icon = fd.icon || '';
+      const iconIsImage = typeof icon === 'string' && !icon.startsWith('fa') && (icon.includes('/') || icon.includes('.'));
       return {
         key: fd.linkedFestival?.festivalKey ?? stub.id,
         noteId: stub.id,
         name: stub.name,
-        icon: fd.icon || '',
+        icon,
+        iconIsImage,
         color: fd.color || '',
         countsForWeekday: fd.linkedFestival?.countsForWeekday ?? true,
         conditionSummary

--- a/scripts/applications/calendar/chronicle.mjs
+++ b/scripts/applications/calendar/chronicle.mjs
@@ -1,7 +1,17 @@
 import { CalendarManager } from '../../calendar/_module.mjs';
 import { HOOKS, MODULE, SETTINGS, SOCKET_TYPES, TEMPLATES } from '../../constants.mjs';
 import { NoteManager, addDays, getPresetDefinition } from '../../notes/_module.mjs';
-import { CalendariaSocket, buildOpenAppsMenuItem, buildScrollEntries, canViewChronicle, dateFormattingParts, getDefaultDateRange, isCombatBlocked, warnShowToAll } from '../../utils/_module.mjs';
+import {
+  CalendariaSocket,
+  buildOpenAppsMenuItem,
+  buildScrollEntries,
+  canAddNotes,
+  canViewChronicle,
+  dateFormattingParts,
+  getDefaultDateRange,
+  isCombatBlocked,
+  warnShowToAll
+} from '../../utils/_module.mjs';
 import { SettingsPanel } from '../_module.mjs';
 
 const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
@@ -132,16 +142,17 @@ export class Chronicle extends HandlebarsApplicationMixin(ApplicationV2) {
       entryDepth: this._entryDepth,
       categoryFilter: this._categoryFilter
     });
-    const isGM = game.user.isGM;
+    const canAdd = canAddNotes();
     for (const entry of this._entries) {
       if (!entry.notes) continue;
       for (const note of entry.notes) if (note.content) note.content = await foundry.applications.ux.TextEditor.implementation.enrichHTML(note.content);
     }
-    context.entries = this._entries.map((e) => ({ ...e, isGM }));
+    context.entries = this._entries.map((e) => ({ ...e, canAdd }));
     context.entryDepth = this._entryDepth;
     context.showEmpty = this._showEmpty;
     context.hasEntries = this._entries.length > 0;
     context.isGM = game.user.isGM;
+    context.canAdd = canAdd;
     context.depths = [
       { id: 'title', label: _loc('CALENDARIA.Chronicle.Depth.Title'), active: this._entryDepth === 'title' },
       { id: 'excerpt', label: _loc('CALENDARIA.Chronicle.Depth.Excerpt'), active: this._entryDepth === 'excerpt' },
@@ -512,7 +523,7 @@ export class Chronicle extends HandlebarsApplicationMixin(ApplicationV2) {
     }
     const parts = [];
     for (const entry of entries) {
-      const html = await foundry.applications.handlebars.renderTemplate(template, { ...entry, isGM: game.user.isGM });
+      const html = await foundry.applications.handlebars.renderTemplate(template, { ...entry, canAdd: canAddNotes() });
       parts.push(html);
     }
     return parts.join('');

--- a/scripts/applications/calendar/chronicle.mjs
+++ b/scripts/applications/calendar/chronicle.mjs
@@ -195,6 +195,7 @@ export class Chronicle extends HandlebarsApplicationMixin(ApplicationV2) {
     if (options.isFirstRender) {
       this.#restorePosition();
       this.#initContextMenu();
+      if (!this._lockedRange) this._scrollToToday = true;
     }
     this.#registerHooks();
     this.#bindSelectListeners();

--- a/scripts/applications/calendar/note-viewer.mjs
+++ b/scripts/applications/calendar/note-viewer.mjs
@@ -1,6 +1,6 @@
 import { CalendarManager } from '../../calendar/_module.mjs';
 import { DISPLAY_STYLES, HOOKS, MODULE, NOTE_VISIBILITY, SETTINGS, TEMPLATES } from '../../constants.mjs';
-import { NoteManager, filterNotes, formatNoteDate, getAllPresets, getAvailableAuthors } from '../../notes/_module.mjs';
+import { NoteManager, compareDates, filterNotes, formatNoteDate, getAllPresets, getAvailableAuthors, getCurrentDate } from '../../notes/_module.mjs';
 import { canAddNotes, canDeleteNotes } from '../../utils/_module.mjs';
 
 const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
@@ -59,6 +59,8 @@ export class NoteViewer extends HandlebarsApplicationMixin(ApplicationV2) {
     this._allFilteredNotes = [];
     this._renderedCount = 0;
     this._loading = false;
+    this._todayIndex = -1;
+    this._initialTodayScroll = true;
     if (options.search) this._filterState.search = options.search;
     if (options.preset) this._filterState.presets.add(options.preset);
     if (options.visibility) this._filterState.visibility = options.visibility;
@@ -166,7 +168,11 @@ export class NoteViewer extends HandlebarsApplicationMixin(ApplicationV2) {
       }
       this._allFilteredNotes = [...direct, ...mentioned];
     }
+    const today = getCurrentDate();
+    this._todayIndex = this._allFilteredNotes.findIndex((row) => row.startDate && compareDates(row.startDate, today) >= 0);
+    if (this._todayIndex >= 0) this._allFilteredNotes[this._todayIndex].isToday = true;
     this._renderedCount = Math.min(BATCH_SIZE, this._allFilteredNotes.length);
+    if (this._initialTodayScroll && this._todayIndex >= this._renderedCount) this._renderedCount = this._todayIndex + 1;
     const calendarIdSet = new Set(calendarIds);
     context.notes = this._allFilteredNotes.slice(0, this._renderedCount);
     const calendarScoped = calendarIdSet.size ? allNotes.filter((n) => calendarIdSet.has(n.calendarId)) : allNotes;
@@ -205,6 +211,10 @@ export class NoteViewer extends HandlebarsApplicationMixin(ApplicationV2) {
     if (options.isFirstRender) {
       this.#centerPosition();
       this.#registerHooks();
+      if (this._initialTodayScroll) {
+        this._initialTodayScroll = false;
+        if (this._todayIndex >= 0) requestAnimationFrame(() => this.element?.querySelector('.note-viewer-today')?.scrollIntoView({ block: 'start' }));
+      }
     }
     this.#bindFilterListeners();
     this.#bindResultListeners();
@@ -265,6 +275,7 @@ export class NoteViewer extends HandlebarsApplicationMixin(ApplicationV2) {
     return {
       id: stub.id,
       name: stub.name,
+      startDate: flagData.startDate,
       dateLabel: formatNoteDate(stub),
       color: flagData.color || '#4a9eff',
       icon: flagData.icon || 'fas fa-calendar',

--- a/scripts/applications/hud/hud-scene-renderer.mjs
+++ b/scripts/applications/hud/hud-scene-renderer.mjs
@@ -655,7 +655,8 @@ export class HudSceneRenderer {
     this.#mode = mode;
     this.#perfConfig = this.#getPerformanceConfig();
     const parent = canvas.parentElement;
-    this.#app = new PIXI.Application({ view: canvas, backgroundAlpha: 0, resizeTo: parent, antialias: true });
+    const resolution = Math.min(window.devicePixelRatio || 1, 2);
+    this.#app = new PIXI.Application({ view: canvas, backgroundAlpha: 0, resizeTo: parent, antialias: true, resolution, autoDensity: true });
     this.#app.ticker.maxFPS = this.#perfConfig.maxFPS;
     this.#buildSkyLayer();
     this.#buildStarLayer();
@@ -836,7 +837,7 @@ export class HudSceneRenderer {
       sprite.anchor.set(0.5);
       sprite.x = rand(4, w - 4);
       sprite.y = rand(4, h * 0.85);
-      sprite.scale.set(rand(0.5, 1.2));
+      sprite.scale.set(rand(0.5, 1.2) * (this.#mode === 'dial' ? (w / 300) * 3 : 1));
       sprite.alpha = 0.5;
       this.#starContainer.addChild(sprite);
       this.#stars.push(sprite);
@@ -1026,7 +1027,7 @@ export class HudSceneRenderer {
       const sunHour = sunrise + sunProgress * daylightHours;
       const angleDegs = sunHour * (360 / hoursPerDay) + 90;
       const angleRads = (angleDegs * Math.PI) / 180;
-      const sunSize = 20;
+      const sunSize = w * 0.09;
       const orbitRadius = w * 0.28;
       this.#sunSprite.x = w / 2 + Math.cos(angleRads) * orbitRadius;
       this.#sunSprite.y = h / 2 + Math.sin(angleRads) * orbitRadius;
@@ -1112,7 +1113,7 @@ export class HudSceneRenderer {
     const h = this.#app.screen.height;
     const count = moons.length;
     const isDial = this.#mode === 'dial';
-    const baseMoonSize = isDial ? 20 : this.#mode === 'dome' ? (w > 120 ? 18 : 14) : w > 110 ? 12 : 10;
+    const baseMoonSize = isDial ? w * 0.09 : this.#mode === 'dome' ? (w > 120 ? 18 : 14) : w > 110 ? 12 : 10;
     const secondaryScale = Math.max(0.6, 0.92 - Math.max(0, count - 3) * 0.03);
     const trailSpacing = baseMoonSize * secondaryScale * 1.3;
     let arcPixels;

--- a/scripts/applications/time/sun-dial.mjs
+++ b/scripts/applications/time/sun-dial.mjs
@@ -673,7 +673,6 @@ export class SunDial extends HandlebarsApplicationMixin(ApplicationV2) {
       await game.time.advance(timeDiff);
       log(3, `Time adjusted by ${timeDiff} seconds to ${this.#formatDialTime(this.#currentHours, this.#currentMinutes)}`);
     }
-    this.#initialTime = this.#initialTime + timeDiff;
   }
 
   /** Set up the right-click context menu on the dial. */

--- a/scripts/data/calendaria-calendar.mjs
+++ b/scripts/data/calendaria-calendar.mjs
@@ -410,7 +410,7 @@ export default class CalendariaCalendar extends foundry.data.CalendarData {
       months: extendedMonthSchema,
       seasons: extendedSeasonSchema,
       days: extendedDaysSchema,
-      secondsPerRound: new NumberField({ required: false, integer: true, min: 1, initial: 6 }),
+      secondsPerRound: new NumberField({ required: false, integer: true, min: 0, initial: 6 }),
       leapYearConfig: new SchemaField(
         {
           rule: new StringField({ required: false, initial: 'none' }),

--- a/scripts/utils/chat/release-message.mjs
+++ b/scripts/utils/chat/release-message.mjs
@@ -9,7 +9,7 @@ export async function checkReleaseMessage() {
   if (!version) return;
   const lastSeen = game.user.getFlag(MODULE.ID, 'lastSeenVersion');
   if (lastSeen === version) return;
-  const repoUrl = `https://github.com/Timemaster-Games/calendaria/releases/tag/release-${version}`;
+  const repoUrl = `https://github.com/Sayshal/Calendaria/releases/tag/release-${version}`;
   const content = await foundry.applications.handlebars.renderTemplate(`modules/${MODULE.ID}/templates/chat/release-message.hbs`, { version, repoUrl });
   await ChatMessage.create({ content, whisper: [game.user.id], speaker: { alias: MODULE.TITLE } });
   await game.user.setFlag(MODULE.ID, 'lastSeenVersion', version);

--- a/styles/big-cal.css
+++ b/styles/big-cal.css
@@ -365,6 +365,13 @@
       font-size: var(--font-size-12);
     }
 
+    img.festival-icon {
+      width: 1em;
+      height: 1em;
+      object-fit: contain;
+      vertical-align: middle;
+    }
+
     .day-weather-pill + .day-notes {
       margin-top: 0;
     }

--- a/styles/calendar-editor.css
+++ b/styles/calendar-editor.css
@@ -193,6 +193,13 @@
 
         opacity: 0.8;
       }
+
+      img {
+        width: 1em;
+        height: 1em;
+        object-fit: contain;
+        vertical-align: middle;
+      }
     }
 
     .festival-name {

--- a/templates/applications/calendar/chronicle-entry.hbs
+++ b/templates/applications/calendar/chronicle-entry.hbs
@@ -85,7 +85,7 @@
         </div>
       {{/if}}
 
-      {{#if isGM}}
+      {{#if canAdd}}
         <button type="button" class="add-note-btn" data-action="addNote" data-year="{{date.year}}"
           data-month="{{date.month}}" data-day="{{date.dayOfMonth}}"
           data-tooltip="{{localize 'CALENDARIA.Chronicle.AddNote'}}">

--- a/templates/applications/calendar/chronicle-timeline-entry.hbs
+++ b/templates/applications/calendar/chronicle-timeline-entry.hbs
@@ -89,7 +89,7 @@
           </div>
         {{/if}}
 
-        {{#if isGM}}
+        {{#if canAdd}}
           <button type="button" class="add-note-btn" data-action="addNote" data-year="{{date.year}}"
             data-month="{{date.month}}" data-day="{{date.dayOfMonth}}"
             data-tooltip="{{localize 'CALENDARIA.Chronicle.AddNote'}}">

--- a/templates/applications/calendar/note-viewer-results.hbs
+++ b/templates/applications/calendar/note-viewer-results.hbs
@@ -3,8 +3,8 @@
     <div class="note-list">
       {{#each notes}}
         {{#if this.groupHeaderLabel}}<div class="note-group-header">{{this.groupHeaderLabel}}</div>{{/if}}
-        <div class="note-row{{#if this.selected}} selected{{/if}}" data-note-id="{{this.id}}"
-          data-preset="{{this.presetId}}" data-visibility="{{this.visibility}}"
+        <div class="note-row{{#if this.selected}} selected{{/if}}{{#if this.isToday}} note-viewer-today{{/if}}"
+          data-note-id="{{this.id}}" data-preset="{{this.presetId}}" data-visibility="{{this.visibility}}"
           data-display-style="{{this.displayStyle}}" style="--note-color: {{this.color}}">
           {{#if ../selectionMode}}
             <input type="checkbox" class="note-select-checkbox" {{#if this.selected}}checked{{/if}} />

--- a/templates/applications/calendar/note-viewer-row.hbs
+++ b/templates/applications/calendar/note-viewer-row.hbs
@@ -1,5 +1,6 @@
 {{#if groupHeaderLabel}}<div class="note-group-header">{{groupHeaderLabel}}</div>{{/if}}
-<div class="note-row{{#if selected}} selected{{/if}}" data-note-id="{{id}}" data-preset="{{presetId}}"
+<div class="note-row{{#if selected}} selected{{/if}}{{#if isToday}} note-viewer-today{{/if}}" data-note-id="{{id}}"
+  data-preset="{{presetId}}"
   data-visibility="{{visibility}}" data-display-style="{{displayStyle}}" style="--note-color: {{color}}">
   {{#if selectionMode}}
     <input type="checkbox" class="note-select-checkbox" {{#if selected}}checked{{/if}} />

--- a/templates/applications/settings/tab-chronicle.hbs
+++ b/templates/applications/settings/tab-chronicle.hbs
@@ -1,22 +1,20 @@
 <section class="tab {{tab.cssClass}}" data-tab="{{tab.id}}" data-group="{{tab.group}}">
 
-  {{#if isGM}}
-    <div class="button-row app-controls">
-      <button type="button" data-action="resetPosition" data-target="chronicle">
-        <i class="fas fa-undo"></i>
-        {{localize "CALENDARIA.Common.ResetPosition"}}
-      </button>
-      <button type="button" data-action="closeChronicle">
-        <i class="fas fa-times"></i>
-        {{localize "CALENDARIA.SettingsPanel.CloseChronicle"}}
-      </button>
-      <button type="button" data-action="openChronicle">
-        <i class="fas fa-external-link-alt"></i>
-        {{localize "CALENDARIA.Common.OpenChronicle"}}
-      </button>
-    </div>
-    <p class="hint section-hint">{{openHint}}</p>
-  {{/if}}
+  <div class="button-row app-controls">
+    <button type="button" data-action="resetPosition" data-target="chronicle">
+      <i class="fas fa-undo"></i>
+      {{localize "CALENDARIA.Common.ResetPosition"}}
+    </button>
+    <button type="button" data-action="closeChronicle">
+      <i class="fas fa-times"></i>
+      {{localize "CALENDARIA.SettingsPanel.CloseChronicle"}}
+    </button>
+    <button type="button" data-action="openChronicle">
+      <i class="fas fa-external-link-alt"></i>
+      {{localize "CALENDARIA.Common.OpenChronicle"}}
+    </button>
+  </div>
+  <p class="hint section-hint">{{openHint}}</p>
 
   <fieldset data-section="chronicle-visibility">
     <legend>

--- a/templates/applications/settings/tab-stopwatch.hbs
+++ b/templates/applications/settings/tab-stopwatch.hbs
@@ -1,22 +1,20 @@
 <section class="tab {{tab.cssClass}}" data-tab="{{tab.id}}" data-group="{{tab.group}}">
 
-  {{#if isGM}}
-    <div class="button-row app-controls">
-      <button type="button" data-action="resetPosition" data-target="stopwatch">
-        <i class="fas fa-undo"></i>
-        {{localize "CALENDARIA.Common.ResetPosition"}}
-      </button>
-      <button type="button" data-action="closeStopwatch">
-        <i class="fas fa-times"></i>
-        {{localize "CALENDARIA.SettingsPanel.CloseStopwatch"}}
-      </button>
-      <button type="button" data-action="openStopwatch">
-        <i class="fas fa-external-link-alt"></i>
-        {{localize "CALENDARIA.Common.OpenStopWatch"}}
-      </button>
-    </div>
-    <p class="hint section-hint">{{openHint}}</p>
-  {{/if}}
+  <div class="button-row app-controls">
+    <button type="button" data-action="resetPosition" data-target="stopwatch">
+      <i class="fas fa-undo"></i>
+      {{localize "CALENDARIA.Common.ResetPosition"}}
+    </button>
+    <button type="button" data-action="closeStopwatch">
+      <i class="fas fa-times"></i>
+      {{localize "CALENDARIA.SettingsPanel.CloseStopwatch"}}
+    </button>
+    <button type="button" data-action="openStopwatch">
+      <i class="fas fa-external-link-alt"></i>
+      {{localize "CALENDARIA.Common.OpenStopWatch"}}
+    </button>
+  </div>
+  <p class="hint section-hint">{{openHint}}</p>
 
   <fieldset data-section="stopwatch-display">
     <legend>

--- a/templates/applications/settings/tab-sun-dial.hbs
+++ b/templates/applications/settings/tab-sun-dial.hbs
@@ -1,22 +1,20 @@
 <section class="tab {{tab.cssClass}}" data-tab="{{tab.id}}" data-group="{{tab.group}}">
 
-  {{#if isGM}}
-    <div class="button-row app-controls">
-      <button type="button" data-action="resetPosition" data-target="sunDial">
-        <i class="fas fa-undo"></i>
-        {{localize "CALENDARIA.Common.ResetPosition"}}
-      </button>
-      <button type="button" data-action="closeSunDial">
-        <i class="fas fa-times"></i>
-        {{localize "CALENDARIA.SettingsPanel.CloseSunDial"}}
-      </button>
-      <button type="button" data-action="openSunDial">
-        <i class="fas fa-external-link-alt"></i>
-        {{localize "CALENDARIA.SettingsPanel.OpenSunDial"}}
-      </button>
-    </div>
-    <p class="hint section-hint">{{openHint}}</p>
-  {{/if}}
+  <div class="button-row app-controls">
+    <button type="button" data-action="resetPosition" data-target="sunDial">
+      <i class="fas fa-undo"></i>
+      {{localize "CALENDARIA.Common.ResetPosition"}}
+    </button>
+    <button type="button" data-action="closeSunDial">
+      <i class="fas fa-times"></i>
+      {{localize "CALENDARIA.SettingsPanel.CloseSunDial"}}
+    </button>
+    <button type="button" data-action="openSunDial">
+      <i class="fas fa-external-link-alt"></i>
+      {{localize "CALENDARIA.SettingsPanel.OpenSunDial"}}
+    </button>
+  </div>
+  <p class="hint section-hint">{{openHint}}</p>
 
   <fieldset data-section="sunDial-display">
     <legend>

--- a/templates/applications/sheets/calendar-grid.hbs
+++ b/templates/applications/sheets/calendar-grid.hbs
@@ -101,7 +101,9 @@
                       <span class="festival-icon-wrapper" {{#if festivalNoteId}}data-action="editNote"
                         data-note-id="{{festivalNoteId}}" {{/if}} data-tooltip
                         aria-label="{{festivalName}}{{#if festivalDescription}}: {{festivalDescription}}{{/if}}">
-                        <i class="{{#if festivalIcon}}{{festivalIcon}}{{else}}fas fa-star{{/if}} festival-icon"></i>
+                        {{#if festivalIconIsImage}}<img src="{{festivalIcon}}" class="festival-icon"
+                          alt="{{festivalName}}">{{else}}<i
+                          class="{{#if festivalIcon}}{{festivalIcon}}{{else}}fas fa-star{{/if}} festival-icon"></i>{{/if}}
                       </span>
                     {{/if}}
                     {{#if moonPhases}}

--- a/templates/chat/release-message.hbs
+++ b/templates/chat/release-message.hbs
@@ -12,12 +12,20 @@
 
     <h4>New Features</h4>
     <ul>
-      <li>A new permission can hide the Note Viewer button from players</li>
+      <li>The Chronicle and Note Viewer jump to today when you open them</li>
     </ul>
 
     <h4>Bug Fixes</h4>
     <ul>
-      <li>The Note Viewer no longer hints at hidden notes through its count</li>
+      <li>Festival icons set to an image or SVG now show on the calendar and festival editor</li>
+      <li>Players with note permission can use the Chronicle's hover Add Note button</li>
+      <li>The sun dial no longer jumps the time around when you drag it</li>
+      <li>The sun, moon, and stars on the HUD look sharper and scale with its size</li>
+    </ul>
+
+    <h4>Changes</h4>
+    <ul>
+      <li>Players with the right permission can open, reset, and close the Chronicle, Stop Watch, and Sun Dial from settings</li>
     </ul>
 
   </div>

--- a/templates/editor/tab-festivals.hbs
+++ b/templates/editor/tab-festivals.hbs
@@ -29,7 +29,8 @@
             <div class="festival-main flexrow">
               <span class="col-icon festival-icon-display"
                 style="color: {{#if this.color}}{{this.color}}{{else}}#d4af37{{/if}}">
-                <i class="{{#if this.icon}}fas {{this.icon}}{{else}}fas fa-star{{/if}}"></i>
+                {{#if this.iconIsImage}}<img src="{{this.icon}}" alt="">{{else}}<i
+                    class="{{#if this.icon}}fas {{this.icon}}{{else}}fas fa-star{{/if}}"></i>{{/if}}
               </span>
               <span class="col-name festival-name">{{this.name}}</span>
               <span class="col-schedule hint">{{this.conditionSummary}}</span>

--- a/templates/editor/tab-time.hbs
+++ b/templates/editor/tab-time.hbs
@@ -34,7 +34,7 @@
       <label for="editor-seconds-per-round">{{localize "CALENDARIA.Editor.Field.SecondsPerRound"}}</label>
       <div class="form-fields">
         <input type="number" id="editor-seconds-per-round" name="secondsPerRound" value="{{calendar.secondsPerRound}}"
-          min="1" step="1">
+          min="0" step="1">
       </div>
     </div>
   </fieldset>


### PR DESCRIPTION
## New Features

- [#773] The Chronicle scrolls to today's entry when first opened, unless it was opened with a locked date range.
- [#773] The Note Viewer scrolls to the first note dated on or after today and places it at the top of the list when first opened.

## Bug Fixes

- [#774] The Chronicle hover Add Note quick-add button now appears for any player with note-creation permission in both the scroll and timeline layouts, not only the GM.
- [#775] The chat card Release Notes link now points to the correct repository.
- [#776] You can now set Seconds Per Round to zero on the calendar Time tab, which stops world time from advancing when combat rounds change.
- [#779] The sun dial no longer jumps the time around on repeated drags or center-input edits.
- [#781] Festivals with an image file icon such as an SVG now render that image on the calendar grid and in the festival editor list instead of nothing.
- The HUD dome sun, moon, and stars render sharper at high resolution and scale with the dial size.

## Changes

- [#780] Darkness sync no longer rewrites scenes whose darkness and lighting already match the computed values, cutting redundant scene updates.
- The Chronicle, Stop Watch, and Sun Dial settings tabs now show the open, reset position, and close controls to any non-GM user holding that app's view permission.
